### PR TITLE
use AB::MB as configure_requires

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -26,7 +26,7 @@ filename = _build
 filename = _share
 filename = _alien
 [Prereqs / ConfigureRequires]
-Alien::Base=0.023
+Alien::Base::ModuleBuild=0.023
 Alien::ProtoBuf=0.01
 [Prereqs / BuildRequires]
 ExtUtils::CppGuess=0.11


### PR DESCRIPTION
This will future proof this distribution for when/if `Alien::Base::ModuleBuild` is spun off from `Alien::Base`.  For the rationale for this change, please see https://github.com/Perl5-Alien/Alien-Base/issues/157
