### PR TITLE
Add IO::Socket::SSL dependency

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -29,6 +29,7 @@ filename = _alien
 Alien::Base::ModuleBuild=0.023
 Alien::ProtoBuf=0.01
 ExtUtils::CppGuess=0.11
+IO::Socket::SSL=1.42
 [Prereqs / TestRequires]
 ; authordep Test::Pod = 1.43
 [ModuleBuild]


### PR DESCRIPTION
The reason for this dependency is that fetching http://github.com/mbarbon/upb/archive/$commit.zip in AU::Build redirects to HTTPS. HTTP::Tiny needs IO::Socket::SSL and Net::SSLeay for HTTPS support.
