### PR TITLE
smooth over build

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -26,8 +26,11 @@ filename = _build
 filename = _share
 filename = _alien
 [Prereqs / ConfigureRequires]
+Alien::Base=0
 Alien::Base::ModuleBuild=0.023
+Alien::gmake=0
 Alien::ProtoBuf=0.01
+Archive::Zip=0
 ExtUtils::CppGuess=0.11
 [Prereqs / TestRequires]
 ; authordep Test::Pod = 1.43

--- a/inc/AU/Build.pm
+++ b/inc/AU/Build.pm
@@ -30,7 +30,7 @@ sub new {
         ],
         alien_repository => {
             protocol        => 'http',
-            exact_filename  => "http://github.com/mbarbon/upb/archive/$commit.zip",
+            exact_filename  => "https://github.com/mbarbon/upb/archive/$commit.zip",
         },
     );
 


### PR DESCRIPTION
during build of last release, we found these requirements are missing.
the path to the zip file is changed to `https` as it solves a proxy related issue we have with `http` - I hope you are fine with that change.