### PR TITLE
specify https as protocol to get https prereqs

### DIFF
--- a/inc/AU/Build.pm
+++ b/inc/AU/Build.pm
@@ -33,7 +33,7 @@ sub new {
             "$^X ../../scripts/install.pl %s",
         ],
         alien_repository => {
-            protocol        => 'http',
+            protocol        => 'https',
             exact_filename  => "https://github.com/mbarbon/upb/archive/$commit.zip",
         },
     );


### PR DESCRIPTION
I recommend using `https` instead of `http` as that will inform `Alien::Base::ModuleBuild` that you will need the SSL prereqs and will add them for you (otherwise it works the same).  For a share install that uses SSL you need `Net::SSLeay` and `IO::Socket::SSL`.